### PR TITLE
added auto naming based on setup

### DIFF
--- a/exp_namer.py
+++ b/exp_namer.py
@@ -1,0 +1,33 @@
+from tomllib import load as tload
+from sys import argv
+from time import time
+
+
+
+def get_name(config):
+    exp_dir_name = ''
+
+    domain_name = config['domain']['name']
+    if (domain_name == 'bpp'):
+        exp_dir_name += f"{config['domain']['args']['dataset_name']}__".lower()
+    else:
+        exp_dir_name += f"{domain_name}__"
+
+    crossover_name = config['crossover']['name']
+    if(crossover_name == 'dnc'):
+        exp_dir_name += f"{crossover_name}_bz{config['crossover']['args']['dnc_config']['batch_size']}_fe{config['crossover']['args']['dnc_config']['fitness_epsilon']}__"
+    else:
+        exp_dir_name += f"{crossover_name}__"
+
+    exp_dir_name += f"{int(time())}"
+    return exp_dir_name
+
+
+
+
+if __name__ == "__main__":
+    setup_file = argv[1]
+    with open(setup_file, 'rb') as f:
+        config = tload(f)
+
+    print(get_name(config))

--- a/exp_runner.py
+++ b/exp_runner.py
@@ -11,6 +11,7 @@ from eckity.genetic_operators.selections.tournament_selection import TournamentS
 from eckity.algorithms.simple_evolution import AFTER_GENERATION_EVENT_NAME
 import tomllib
 from torch.cuda import is_available as is_cuda_aviable
+from exp_namer import get_name
 
 def main(output_dir:str, setup_file:str=None):
 
@@ -54,6 +55,7 @@ def main(output_dir:str, setup_file:str=None):
                                                    evaluator=evaluator,
                                                    individual_length=individual_length,
                                                    **config['crossover']['args'])
+        
     elif(crossover_name == 'kpoint'):
         crossover_op = EckityFactory.create_kpoint_crossover(**config['crossover']['args'])
     else:
@@ -68,7 +70,7 @@ def main(output_dir:str, setup_file:str=None):
     else:
         raise ValueError(f'Operator {mutation_name} not recognized')
 
-    
+
     # Logger setup
     statistics_logger = Logger(output_path=os.path.join(output_dir, 'statistics.csv'))
     statistics_logger.add_time_col()

--- a/scripts/measure.sh
+++ b/scripts/measure.sh
@@ -5,13 +5,12 @@ export PATH="/home/foyer/.conda/envs/energy_measure/bin/:/home/debian/anaconda3/
 
 OUT_DIR=""
 NUM_EXPS=1
-SETUP_FILE="setups/setup.toml"
-
+SETUP_FILE=""
 
 while getopts "o:n:s:" opt; do
   case "$opt" in
     o)
-        OUT_DIR="out_files/exp_$OPTARG"
+        OUT_DIR="$OPTARG"
         ;;
     
     n)
@@ -34,11 +33,13 @@ if [ -z "$SETUP_FILE" ]; then
 fi
 
 
+EXP_DIR=$(python exp_namer.py $SETUP_FILE 2>&1)
+OUT_DIR="$OUT_DIR/$EXP_DIR"
 
 mkdir -p $OUT_DIR
-sudo chmod a+w,a+r $OUT_DIR
+chmod a+w,a+r $OUT_DIR
 OUT_FILE=$OUT_DIR/raw.txt
 
 pinpoint -c --timestamp -r $NUM_EXPS -i 250 -e rapl:pkg,GPU -o $OUT_FILE -- python exp_runner.py --setup_file $SETUP_FILE -o $OUT_DIR
-chmod a+w,a+r $OUT_FILE
+chmod a+r $OUT_FILE
 

--- a/setups/quick.toml
+++ b/setups/quick.toml
@@ -1,0 +1,23 @@
+[domain]
+    name='bpp'
+    [domain.args]
+        db_path = "datasets_dnc/hard_parsed.json"
+        dataset_name = "BPP_14"
+
+[crossover]
+    name='kpoint'
+    [crossover.args]
+        probability = 0.5
+        k = 1
+        arity = 2
+
+[mutation]
+    name='uniform'
+    [mutation.args]
+        probability = 0.5
+        probability_for_each = 0.1
+        arity = 1
+
+[evolution]
+    max_generation = 50
+    population_size = 100


### PR DESCRIPTION
## Summary by Sourcery

Integrate automatic experiment naming based on setup files by adding exp_namer.py and invoking it in measure.sh, update default setup behavior and output directory creation, include an example quick.toml setup, and streamline permission handling.

New Features:
- Add exp_namer.py to generate experiment directory names from TOML configurations
- Invoke exp_namer in measure.sh to auto-append generated experiment directory to the output path
- Provide an example setup file (setups/quick.toml)

Enhancements:
- Change default SETUP_FILE to be unset to require explicit specification
- Remove sudo and simplify chmod usage for directories and output files in measure.sh
- Import get_name in exp_runner.py for future naming integration