### PR TITLE
Develop

### DIFF
--- a/EckityExtended/ECkityFactory.py
+++ b/EckityExtended/ECkityFactory.py
@@ -106,7 +106,7 @@ def create_simple_evo(
         breeder=breeder if breeder is not None else SimpleBreeder(),
         max_workers=max_workers,
         max_generation=max_generation,
-        statistics=statistics if statistics is not None else BestAverageWorstStatistics(should_print=False), random_seed=4242,should_print=False
+        statistics=statistics, random_seed=4242,should_print=False
     )
     if(loggers is not None and log_events is not None
         and len(loggers) == len(log_events)):

--- a/exp_runner.py
+++ b/exp_runner.py
@@ -93,7 +93,6 @@ def main(output_dir:str, setup_file:str=None):
                                                            log_events=[AFTER_GENERATION_EVENT_NAME])
     
     statistics_logger.add_best_of_gen_col(evo_algo)
-    statistics_logger.add_average_col(evo_algo)
     statistics_logger.add_gen_col(evo_algo)
 
     if(crossover_name == 'dnc'):


### PR DESCRIPTION
## Summary by Sourcery

Remove implicit default statistics instantiation and disable average generation logging to streamline custom statistics handling

Enhancements:
- Stop instantiating BestAverageWorstStatistics when no statistics object is provided to create_simple_evo
- Remove the add_average_col call from the statistics logger in exp_runner.py